### PR TITLE
Remove Deprecated Image

### DIFF
--- a/challenge-03/Dockerfile
+++ b/challenge-03/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM eclipse-temurin:17-jdk
 
 WORKDIR /app
 

--- a/challenge-05/Dockerfile
+++ b/challenge-05/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM eclipse-temurin:17-jdk
 
 WORKDIR /app
 

--- a/challenge-16/Dockerfile
+++ b/challenge-16/Dockerfile
@@ -1,6 +1,8 @@
-FROM maven:3.8.5-openjdk-17 AS build
+FROM eclipse-temurin:17-jdk AS build
 
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y maven
 
 COPY pom.xml .
 

--- a/challenge-20/Dockerfile
+++ b/challenge-20/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 
 # Install Maven
 RUN apt-get update && apt-get install -y maven

--- a/challenge-23/Dockerfile
+++ b/challenge-23/Dockerfile
@@ -1,13 +1,15 @@
-FROM maven:3.8.6-openjdk-11-slim AS builder
+FROM eclipse-temurin:17-jdk AS builder
 
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y maven
 
 COPY pom.xml /app/
 COPY src /app/src/
 
 RUN mvn clean package -DskipTests
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:17-jre
 
 WORKDIR /app
 


### PR DESCRIPTION
- The openjdk:17-slim image is no longer available on Docker Hub (OpenJDK images were deprecated).